### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
-all:
-	GOOS=linux GOARCH=amd64 go build -o application application.go inspector.go blacklist.go region.go
-	GOOS=linux GOARCH=amd64 go build -o populate populate.go region.go
-	zip -r dufflebag.zip application populate .ebextensions/
+GOARGS := GOOS=linux GOARCH=amd64 go build -o
 
+.PHONY: fetchdependencies
+fetchdependencies:
+	@echo "Generating temporary module."
+	@go mod init github.com/BishopFox/dufflebag
+	@go mod tidy
+
+.PHONY: all
+all: fetchdependencies application populate dufflebag.zip
+
+application: application.go inspector.go blacklist.go region.go
+	@echo "Building application binary."
+	${GOARGS} $@ $^
+
+populate: populate.go region.go
+	@echo "Building populate binary."
+	@${GOARGS} $@ $^
+
+dufflebag.zip: application populate .ebextensions/
+	@echo "Compressing dufflebag.zip."
+	@zip -r $@ $^
+
+.PHONY: clean
 clean:
-	rm -f application populate dufflebag.zip
+	@rm -f application populate dufflebag.zip
+	@rm -f go.mod go.sum


### PR DESCRIPTION
Reflect deprecation of `go get` for non-module repositories.

This will create a temporary module reflective of repository name for building.
